### PR TITLE
Improve past recs

### DIFF
--- a/helpers/cli.ts
+++ b/helpers/cli.ts
@@ -1,0 +1,43 @@
+const commandLineUsage = require('command-line-usage')
+
+const sections = [
+    {
+        header: "Nora",
+        content: "Node R/a/dio archiver, for saving your streams. For a gui check out: {underline https://github.com/Linkcube/svelte-radio-interface}"
+    },
+    {
+        header: "Options",
+        optionList: [
+            {
+                name: "load_config",
+                alias: "l",
+                typeLabel: "{underline file}",
+                description: "Loads a JSON config file for the main program, use with --start."
+            },
+            {
+                name: "start",
+                alias: "s",
+                type: Boolean,
+                description: "Starts the main program."
+            },
+            {
+                name: "process",
+                alias: "p",
+                typeLabel: "{underline file}",
+                description: "Process a previous recording."
+            }
+        ]
+    },
+    {
+        content: 'Project home: {underline https://github.com/Linkcube/Nora}'
+      }
+]
+
+export const usage = commandLineUsage(sections);
+
+export const cli_opts = [
+    { name: "load_config", alias: "l", type: String },
+    { name: "start", type: Boolean },
+    { name: "process", alias: "p", type: String },
+    { name: "help", alias: "h", type: Boolean }
+];

--- a/helpers/recording_processor.ts
+++ b/helpers/recording_processor.ts
@@ -1,0 +1,174 @@
+import {
+    SongObject,
+    MetaDataObject,
+    SharedDataObject
+} from './types';
+
+var fs = require('fs');
+var path = require('path');
+var rmdir = require('rimraf');
+var NodeID3 = require('node-id3');
+var ffmpeg = require('fluent-ffmpeg');
+// Platform agnostic ffmpeg/ffprobe install
+const ffmpegPath: string = require('@ffmpeg-installer/ffmpeg').path;
+ffmpeg.setFfmpegPath(ffmpegPath);
+const ffprobePath: string = require('@ffprobe-installer/ffprobe').path;
+ffmpeg.setFfprobePath(ffprobePath);
+
+function format_seconds(seconds: number) {
+    var measuredTime = new Date(null);
+    measuredTime.setSeconds(seconds);
+    return measuredTime.toISOString().substr(11, 8);
+}
+
+function multi_thread(shared_data: SharedDataObject, song_list: SongObject[], meta_list: MetaDataObject[]) {
+    return new Promise(async (resolve, reject) => {
+        for (let i = 0; i < song_list.length; i++) {
+            let song = song_list[i];
+            let meta = meta_list[i];
+            await split_song(shared_data, song, meta);
+        }
+        resolve();
+    });
+};
+
+function cleanup_post_processing(shared_data: SharedDataObject) {
+    rmdir(shared_data.folder, (err) => {
+        if (err)
+            console.log(err);
+    });
+    console.log("Finished splitting");
+};
+
+function split_song(shared_data: SharedDataObject, song: SongObject, meta: MetaDataObject) {
+    if (song.duration == 0)
+        return null;
+    return new Promise((resolve, reject) => {
+        ffmpeg(shared_data.raw_path)
+            .output(song.filename)
+            .seek(format_seconds(song.start))
+            .audioBitrate(shared_data.bitrate)
+            .audioChannels(2)
+            .audioFrequency(shared_data.sample_rate)
+            .duration(song.duration)
+            .on('end', () => {
+                // ID3 tagging
+                let tags = {
+                    title: meta.song_name,
+                    artist: meta.artist,
+                    album: song.album,
+                    APIC: song.cover,
+                    trackNumber: meta.track,
+                    date: shared_data.date,
+                    performerInfo: song.dj,
+                };
+                NodeID3.write(tags, song.filename);
+                resolve();
+            })
+            .on('error', (err) => {
+                if (err)
+                    throw err;
+                reject();
+            })
+            .run();
+    });
+};
+
+export function process_recording(folder: String) {
+    // Read from a shared folder
+    let shared_data_path = path.format({
+        dir: folder,
+        base: "shared_data.json"
+    });
+    let shared_data: SharedDataObject = JSON.parse(fs.readFileSync(shared_data_path));
+    
+    let song_list_path = path.format({
+        dir: folder,
+        base: "song_list.json"
+    });
+    let song_list: SongObject[] = JSON.parse(fs.readFileSync(song_list_path));
+    
+    let meta_list_path = path.format({
+        dir: folder,
+        base: "meta_list.json"
+    });
+    let meta_list: MetaDataObject[] = JSON.parse(fs.readFileSync(meta_list_path));
+
+    // Handle older recordings
+    if (!shared_data.hasOwnProperty("bitrate")) {
+        shared_data.bitrate = 192
+    }
+    if (!shared_data.hasOwnProperty("sample_rate")) {
+        shared_data.sample_rate = 44100
+    }
+    
+    // Actual splitting
+    if (Object.keys(song_list).length != 0) {
+        console.log(`Splitting ${shared_data.folder}`);
+
+        ffmpeg(shared_data.raw_path).ffprobe((err, data) => {
+            if (err) {
+                console.log(`ffprobe error: ${err}`);
+                return;
+            }
+            // Calculate duration of each song
+            let song_count = 0;
+            song_list.forEach((song) => {
+                let duration;
+                if (song_count == song_list.length - 1) {
+                    duration = data.format.duration;
+                }
+                else if (song.start > data.format.duration) {
+                    console.log(`Error: song starts after end of stream ${song.filename}`);
+                    duration = 0;
+                    song.start = 0;
+                }
+                else {
+                    duration = song_list[song_count + 1].start - song.start;
+                }
+                song.duration = duration;
+                song_count++;
+            });
+            // Split the file
+            let threads = 2;
+            if (threads < 1) {
+                // Kill the CPU
+                threads = song_list.length;
+            }
+            // Multi-thread
+            let promises = [];
+            for (let i = 0; i < threads; i++) {
+                let sub_song = song_list.slice(song_list.length / threads * i, song_list.length / threads * (i + 1));
+                let sub_meta = meta_list.slice(meta_list.length / threads * i, meta_list.length / threads * (i + 1));
+                ;
+                promises.push(multi_thread(shared_data, sub_song, sub_meta));
+            }
+            Promise.all(promises).then(() => {
+                cleanup_post_processing(shared_data);;
+            }).catch(error => {
+                console.log(`Caught an error when splitting: ${error}`);
+            })
+        });
+    }
+};
+
+export function process(shared_data: SharedDataObject, song_list: SongObject[], meta_list: MetaDataObject[]) {
+    // Store song and meta list in case of process failure
+    let song_list_path = path.format({
+        dir: shared_data.folder,
+        base: "song_list.json"
+    });
+    fs.writeFileSync(song_list_path, JSON.stringify(song_list));
+    let meta_list_path = path.format({
+        dir: shared_data.folder,
+        base: "meta_list.json"
+    });
+    fs.writeFileSync(meta_list_path, JSON.stringify(meta_list));
+    let shared_data_path = path.format({
+        dir: shared_data.folder,
+        base: "shared_data.json"
+    });
+    fs.writeFileSync(shared_data_path, JSON.stringify(shared_data));
+
+    process_recording(shared_data.folder);
+};

--- a/helpers/recording_reader.ts
+++ b/helpers/recording_reader.ts
@@ -1,0 +1,65 @@
+var fs = require('fs');
+var path = require('path');
+var NodeID3 = require('node-id3');
+var _ = require('lodash');
+
+let export_folder;
+let max_dirs_sent = 0;
+
+export function update_reader(new_export_folder) {
+    export_folder = new_export_folder;
+}
+
+export var getPastRecordings = () => {
+    let dirs = fs.readdirSync(export_folder, { withFileTypes: true }).filter(
+        file => (file.isDirectory() && file.name.split(' ').length === 2)
+    ).map(dir => dir.name);
+    let result = [];
+    dirs.reverse();
+    if (max_dirs_sent > 0) dirs = dirs.slice(0, max_dirs_sent);
+    dirs.forEach((dir) => {
+        result.push({ folder: dir, songs: getSongCount(dir), cover: getRecordingCoverPath(dir) });
+    });
+    return { recordings: result };
+};
+
+export var getRecordedSongs = (data) => {
+    let dirs = fs.readdirSync(path.join(export_folder, data.folder), { withFileTypes: true }).filter(
+        file => (file.isFile() && file.name.split(' ').length > 1)
+    );
+    dirs.sort((a, b) => {
+        return a.name.split('.')[0] - b.name.split('.')[0];
+    });
+    return { songs: dirs.map(dir => getSongMetadata(path.join(export_folder, data.folder), dir.name))};
+};
+
+var getSongMetadata = (folder, file) => {
+    let tags = NodeID3.read(path.join(folder, file));
+    return { title: tags.title, artist: tags.artist, file: file };
+}
+
+var getSongCount = (folder) => {
+    let dirs = fs.readdirSync(path.join(export_folder, folder), { withFileTypes: true }).filter(
+        file => (file.isFile() && file.name.split(' ').length > 1)
+    );
+    return dirs.length;
+};
+
+export var getRecordingCover = (data) => {
+    let cover = fs.readdirSync(path.join(export_folder, data.folder), { withFileTypes: true }).filter(
+        file => (file.isFile() && file.name.split('.').slice(0, 1).join('.') === "cover")
+    );
+    let cover_path = path.join(export_folder, data.folder, cover[0].name);
+
+    return { cover: fs.readFileSync(cover_path, 'base64')};
+};
+
+var getRecordingCoverPath = (folder) => {
+    let cover = fs.readdirSync(path.join(export_folder, folder), { withFileTypes: true }).filter(
+        file => (file.isFile() && file.name.split('.').slice(0, 1).join('.') === "cover")
+    );
+    if (_.isEmpty(cover)) {
+        return null;
+    }
+    return encodeURI(path.join(folder, cover[0].name));
+};

--- a/helpers/schema.ts
+++ b/helpers/schema.ts
@@ -1,0 +1,85 @@
+const { buildSchema } = require('graphql');
+
+export let Schema = buildSchema(`
+    type Query {
+        api: api_obj
+        server: server_obj
+        valid: is_valid
+        misc: misc_data
+        config: config_data
+        past_recordings: all_recordings
+        recording_cover(folder: String!): cover_data
+        full_recording(folder: String!): full_recording_data
+    },
+    type Mutation {
+        updateConfig(config: new_config): String
+        printLog(msg: String): String
+        streamAction(action: String): String
+    }
+    type api_obj {
+        np: String
+        listeners: Int
+        dj_name: String
+        dj_pic: String
+        start_time: String
+        end_time: String
+        current_time: String
+        lp: [lp_song]
+    },
+    type server_obj {
+        bitrate: Int
+        sample_rate: Int
+        audio_format: String
+        server_name: String
+        server_description: String
+    },
+    type is_valid {
+        valid_dj: Boolean
+        force_stop: Boolean
+    }
+    type misc_data {
+        dj_image_link: String
+        rec_start: Int
+    }
+    type lp_song {
+        meta: String
+        time: String
+        type: Int
+        timestamp: Int
+    }
+    type config_data {
+        api_uri: String
+        server_uri: String
+        stream_uri: String
+        poll_interval: Int
+        excluded_djs: [String]
+        export_folder: String
+    }
+    type all_recordings {
+        recordings: [recordings_data]
+    }
+    type recordings_data {
+        folder: String
+        songs: Int
+        cover: String
+    }
+    type cover_data {
+        cover: String
+    }
+    type full_recording_data {
+        songs: [song_data]
+    }
+    type song_data {
+        title: String
+        artist: String
+        file: String
+    }
+    input new_config {
+        api_uri: String
+        server_uri: String
+        stream_uri: String
+        poll_interval: Int
+        excluded_djs: [String]
+        export_folder: String
+    }
+`);

--- a/helpers/types.ts
+++ b/helpers/types.ts
@@ -1,0 +1,56 @@
+
+export interface ServerObject {
+    bitrate: number,
+    sample_rate: number,
+    audio_format: string,
+    server_name: string,
+    server_description: string
+};
+
+export interface ApiObject {
+    np: string,
+    listeners: number,
+    dj_name: string,
+    dj_pic: string,
+    start_time: number,
+    end_time: number,
+    current_time: number,
+    lp: [],
+};
+
+export interface SongObject {
+    start: number,
+    filename: string,
+    dj: string,
+    cover: string,
+    album: string,
+    duration?: number
+};
+
+export interface MetaDataObject {
+    song_name: string,
+    artist: string,
+    location: string,
+    track: number,
+};
+
+export interface SharedDataObject {
+    date: number,
+    raw_path: string,
+    folder: string,
+    bitrate: number,
+    sample_rate: number
+};
+
+export interface UpdateDataObject {
+    config: UpdateConfigObject
+};
+
+interface UpdateConfigObject {
+    api_uri: string,
+    server_uri: string,
+    stream_uri: string,
+    poll_interval: number,
+    excluded_djs: string[],
+    export_folder: string
+};

--- a/nora.ts
+++ b/nora.ts
@@ -1,57 +1,39 @@
-import { promises } from "dns";
+import {
+    ServerObject,
+    ApiObject,
+    SongObject,
+    MetaDataObject,
+    UpdateDataObject,
+} from './helpers/types';
+import { Schema } from './helpers/schema';
 
 var app; // express app
-var http_server; // replace with gql
+var http_server;
 var polling_interval_id;
 var rp = require('request-promise');
 var http = require('http');
-var https = require('https');
 var fs = require('fs');
 var path = require('path');
-var url = require('url');
-var rmdir = require('rimraf');
 var sane_fs = require('sanitize-filename');
 var request = require('request');
-var NodeID3 = require('node-id3');
-var ffmpeg = require('fluent-ffmpeg');
 var _ = require('lodash');
 var cli_args = require('command-line-args');
-// Platform agnostic ffmpeg/ffprobe install
-const ffmpegPath: string = require('@ffmpeg-installer/ffmpeg').path;
-ffmpeg.setFfmpegPath(ffmpegPath);
-const ffprobePath: string = require('@ffprobe-installer/ffprobe').path;
-ffmpeg.setFfprobePath(ffprobePath);
 var express = require('express');
 var express_graphql = require('express-graphql');
-var { buildSchema } = require('graphql');
 var cors = require('cors');
+var recording_reader = require('./helpers/recording_reader');
+var recording_processor = require('./helpers/recording_processor');
+var cli = require('./helpers/cli');
 var api_uri: string = "https://r-a-d.io/api";
 var server_uri: string = "https://stream.r-a-d.io/status-json.xsl";
 var stream_uri: string = "https://relay0.r-a-d.io/main.mp3";
 var poll_interval: number = 5000;
-interface ServerObject {
-    bitrate: number,
-    sample_rate: number,
-    audio_format: string,
-    server_name: string,
-    server_description: string
-}
 var server: ServerObject = {
     bitrate: 0,
     sample_rate: 0,
     audio_format: "",
     server_name: "",
     server_description: ""
-};
-interface ApiObject {
-    np: string,
-    listeners: number,
-    dj_name: string,
-    dj_pic: string,
-    start_time: number,
-    end_time: number,
-    current_time: number,
-    lp: [],
 };
 var api: ApiObject = {
     np: "",
@@ -67,21 +49,7 @@ var current_song: number = 1;
 var stream_request;
 var folder: string = "";
 var export_folder: string = path.join(".", "recordings_folder");
-interface SongObject {
-    start: number,
-    filename: string,
-    dj: string,
-    cover: string,
-    album: string,
-    duration?: number
-}
 var song_list: SongObject[] = [];
-interface MetaDataObject {
-    song_name: string,
-    artist: string,
-    location: string,
-    track: number,
-}
 var metadata_list: MetaDataObject[] = [];
 var rec_start: number;
 var cover_path: string = "";
@@ -90,35 +58,18 @@ var last_rec: Boolean = false;
 var output_folders: string[] = [];
 var excluded_djs: string[] = ["Hanyuu-sama"];
 var split_character: string = " - ";
-var max_dirs_sent: number = 0; // 0 = unlimited
-interface SharedDataObject {
-    date: number,
-    raw_path: string,
-    folder: string
-}
-interface UpdateDataObject {
-    config: UpdateConfigObject
-}
-interface UpdateConfigObject {
-    api_uri: string,
-    server_uri: string,
-    stream_uri: string,
-    poll_interval: number,
-    excluded_djs: string[],
-    export_folder: string
-}
 
 function resolve_after_get(x: string) {
     return rp(x).then(function (result: string) {
         return (JSON.parse(result));
     });
-}
+};
 
 function format_seconds(seconds: number) {
     var measuredTime = new Date(null);
     measuredTime.setSeconds(seconds);
     return measuredTime.toISOString().substr(11, 8);
-}
+};
 
 function gen_song_meta(filename: string) {
     var song_name, artist;
@@ -136,7 +87,7 @@ function gen_song_meta(filename: string) {
         location: filename,
         track: current_song,
     };
-}
+};
 
 function song_change() {
     let start;
@@ -158,7 +109,7 @@ function song_change() {
     metadata_list.push(gen_song_meta(filename));
     console.log(current_song + ". " + sane_fs(api.np) + " ::" + format_seconds(start) + "::");
     current_song += 1;
-}
+};
 
 function get_dj_pic() {
     let dj_pic_url = api_uri + "/dj-image/" + api.dj_pic;
@@ -173,136 +124,7 @@ function get_dj_pic() {
     });
     request(dj_pic_url).pipe(fs.createWriteStream(cover_path)).on('close', () => {
     });
-}
-
-function split_song(shared_data: SharedDataObject, song: SongObject, meta: MetaDataObject) {
-    if (song.duration == 0)
-        return null;
-    return new Promise((resolve, reject) => {
-        ffmpeg(shared_data.raw_path)
-            .output(song.filename)
-            .seek(format_seconds(song.start))
-            .audioBitrate(server.bitrate)
-            .audioChannels(2)
-            .audioFrequency(server.sample_rate)
-            .duration(song.duration)
-            .on('end', () => {
-                // ID3 tagging
-                let tags = {
-                    title: meta.song_name,
-                    artist: meta.artist,
-                    album: song.album,
-                    APIC: song.cover,
-                    trackNumber: meta.track,
-                    date: shared_data.date,
-                    performerInfo: song.dj,
-                };
-                NodeID3.write(tags, song.filename);
-                resolve();
-            })
-            .on('error', (err) => {
-                if (err)
-                    throw err;
-                reject();
-            })
-            .run();
-    });
-}
-
-function multi_thread(shared_data: SharedDataObject, song_list: SongObject[], meta_list: MetaDataObject[]) {
-    return new Promise(async (resolve, reject) => {
-        for (let i = 0; i < song_list.length; i++) {
-            let song = song_list[i];
-            let meta = meta_list[i];
-            await split_song(shared_data, song, meta);
-        }
-        resolve();
-    });
-}
-
-function cleanup_post_processing(shared_data: SharedDataObject) {
-    rmdir(shared_data.folder, (err) => {
-        if (err)
-            console.log(err);
-    });
-    console.log("Finished splitting");
-}
-
-function process_recording(shared_data: SharedDataObject, song_list: SongObject[], meta_list: MetaDataObject[]) {
-    // Store song and meta list for repeat testing
-    let song_list_path = path.format({
-        dir: shared_data.folder,
-        base: "song_list.json"
-    });
-    fs.writeFile(song_list_path, JSON.stringify(song_list), (err) => {
-        if (err)
-            console.log(err);
-    });
-    let meta_list_path = path.format({
-        dir: shared_data.folder,
-        base: "meta_list.json"
-    });
-    fs.writeFile(meta_list_path, JSON.stringify(meta_list), (err) => {
-        if (err)
-            console.log(err);
-    });
-    let shared_data_path = path.format({
-        dir: shared_data.folder,
-        base: "shared_data.json"
-    });
-    fs.writeFile(shared_data_path, JSON.stringify(shared_data), (err) => {
-        if (err)
-            console.log(err);
-    });
-    // Actual splitting
-    if (Object.keys(song_list).length != 0) {
-        console.log(`Splitting ${shared_data.folder}`);
-
-        ffmpeg(shared_data.raw_path).ffprobe((err, data) => {
-            if (err) {
-                console.log(`ffprobe error: ${err}`);
-                return;
-            }
-            // Calculate duration of each song
-            let song_count = 0;
-            song_list.forEach((song) => {
-                let duration;
-                if (song_count == song_list.length - 1) {
-                    duration = data.format.duration;
-                }
-                else if (song.start > data.format.duration) {
-                    console.log(`Error: song starts after end of stream ${song.filename}`);
-                    duration = 0;
-                    song.start = 0;
-                }
-                else {
-                    duration = song_list[song_count + 1].start - song.start;
-                }
-                song.duration = duration;
-                song_count++;
-            });
-            // Split the file
-            let threads = 2;
-            if (threads < 1) {
-                // Kill the CPU
-                threads = song_list.length;
-            }
-            // Multi-thread
-            let promises = [];
-            for (let i = 0; i < threads; i++) {
-                let sub_song = song_list.slice(song_list.length / threads * i, song_list.length / threads * (i + 1));
-                let sub_meta = meta_list.slice(meta_list.length / threads * i, meta_list.length / threads * (i + 1));
-                ;
-                promises.push(multi_thread(shared_data, sub_song, sub_meta));
-            }
-            Promise.all(promises).then(() => {
-                cleanup_post_processing(shared_data);;
-            }).catch(error => {
-                console.log(`Caught an error when splitting: ${error}`);
-            })
-        });
-    }
-}
+};
 
 function start_streaming(parent_dir) {
     console.log(`Starting stream recording: ${stream_uri}`);
@@ -324,7 +146,7 @@ function start_streaming(parent_dir) {
             ),
             base: "raw_recording.mp3"
         }), { flags: 'w' }))
-}
+};
 
 function teardown() {
     return new Promise(() => {
@@ -342,9 +164,11 @@ function teardown() {
                     ),
                     base: 'raw_recording.mp3'
                 }),
-                folder: path.join(export_folder, folder)
+                folder: path.join(export_folder, folder),
+                bitrate: server.bitrate,
+                sample_rate: server.sample_rate
             };
-            process_recording(shared_data, _.clone(song_list), _.clone(metadata_list));
+            recording_processor.process(shared_data, _.clone(song_list), _.clone(metadata_list));
             last_rec = false;
         }
         song_list = [];
@@ -352,7 +176,7 @@ function teardown() {
         current_song = 1;
         rec_start = null;
     });
-}
+};
 
 function dj_change() {
     // Don't break the stream on a new dj
@@ -392,7 +216,7 @@ function dj_change() {
             song_change();
         }
     });
-}
+};
 
 function poll_api() {
     resolve_after_get(api_uri).then((results) => {
@@ -431,7 +255,7 @@ function poll_api() {
             // pass
         }
     });
-}
+};
 
 function poll_server() {
     resolve_after_get(server_uri).then((results) => {
@@ -451,14 +275,13 @@ function poll_server() {
             // pass
         }
     });
-}
-
+};
 
 function start_server() {
     app = express();
     app.use(cors()); // For graphql over http
     app.use('/graphql', express_graphql({
-        schema: schema,
+        schema: Schema,
         rootValue: root,
         graphiql: true
     }));
@@ -467,7 +290,7 @@ function start_server() {
     app.use(express.static(path.resolve(export_folder)));
     http_server.listen(8080);
     console.log("HTTP server running on localhost:8080");
-}
+};
 
 function start_polling() {
     force_stop = false;
@@ -476,97 +299,16 @@ function start_polling() {
     setTimeout(() => {
         polling_interval_id = setInterval(poll_api, poll_interval);
     }, 1000);
-}
+};
 
-var schema = buildSchema(`
-    type Query {
-        api: api_obj
-        server: server_obj
-        valid: is_valid
-        misc: misc_data
-        config: config_data
-        past_recordings: all_recordings
-        recording_cover(folder: String!): cover_data
-        full_recording(folder: String!): full_recording_data
-    },
-    type Mutation {
-        updateConfig(config: new_config): String
-        printLog(msg: String): String
-        streamAction(action: String): String
-    }
-    type api_obj {
-        np: String
-        listeners: Int
-        dj_name: String
-        dj_pic: String
-        start_time: String
-        end_time: String
-        current_time: String
-        lp: [lp_song]
-    },
-    type server_obj {
-        bitrate: Int
-        sample_rate: Int
-        audio_format: String
-        server_name: String
-        server_description: String
-    },
-    type is_valid {
-        valid_dj: Boolean
-        force_stop: Boolean
-    }
-    type misc_data {
-        dj_image_link: String
-        rec_start: Int
-    }
-    type lp_song {
-        meta: String
-        time: String
-        type: Int
-        timestamp: Int
-    }
-    type config_data {
-        api_uri: String
-        server_uri: String
-        stream_uri: String
-        poll_interval: Int
-        excluded_djs: [String]
-        export_folder: String
-    }
-    type all_recordings {
-        recordings: [recordings_data]
-    }
-    type recordings_data {
-        folder: String
-        songs: Int
-        cover: String
-    }
-    type cover_data {
-        cover: String
-    }
-    type full_recording_data {
-        songs: [song_data]
-    }
-    type song_data {
-        title: String
-        artist: String
-        file: String
-    }
-    input new_config {
-        api_uri: String
-        server_uri: String
-        stream_uri: String
-        poll_interval: Int
-        excluded_djs: [String]
-        export_folder: String
-    }
-`);
 var getApi = () => {
     return api;
 };
+
 var getServer = () => {
     return server;
 };
+
 var isValidDj = () => {
     let valid = {
         valid_dj: !(excluded_djs.includes(api.dj_name)),
@@ -574,12 +316,14 @@ var isValidDj = () => {
     };
     return valid;
 };
+
 var getMiscData = () => {
     return {
         dj_image_link: api_uri + "/dj-image/" + api.dj_pic,
         rec_start: rec_start
     };
 };
+
 var getConfigData = () => {
     return {
         api_uri: api_uri,
@@ -590,54 +334,7 @@ var getConfigData = () => {
         export_folder: export_folder
     };
 };
-var getPastRecordings = () => {
-    let dirs = fs.readdirSync(export_folder, { withFileTypes: true }).filter(
-        file => (file.isDirectory() && file.name.split(' ').length === 2)
-    ).map(dir => dir.name);
-    let result = [];
-    dirs.reverse();
-    if (max_dirs_sent > 0) dirs = dirs.slice(0, max_dirs_sent);
-    dirs.forEach((dir) => {
-        result.push({ folder: dir, songs: getSongCount(dir), cover: getRecordingCoverPath(dir) });
-    });
-    return { recordings: result };
-};
-var getRecordedSongs = (data) => {
-    let dirs = fs.readdirSync(path.join(export_folder, data.folder), { withFileTypes: true }).filter(
-        file => (file.isFile() && file.name.split(' ').length > 1)
-    );
-    dirs.sort((a, b) => {
-        return a.name.split('.')[0] - b.name.split('.')[0];
-    });
-    return { songs: dirs.map(dir => getSongMetadata(path.join(export_folder, data.folder), dir.name))};
-};
-var getSongMetadata = (folder, file) => {
-    let tags = NodeID3.read(path.join(folder, file));
-    return { title: tags.title, artist: tags.artist, file: file };
-}
-var getSongCount = (folder) => {
-    let dirs = fs.readdirSync(path.join(export_folder, folder), { withFileTypes: true }).filter(
-        file => (file.isFile() && file.name.split(' ').length > 1)
-    );
-    return dirs.length;
-};
-var getRecordingCover = (data) => {
-    let cover = fs.readdirSync(path.join(export_folder, data.folder), { withFileTypes: true }).filter(
-        file => (file.isFile() && file.name.split('.').slice(0, 1).join('.') === "cover")
-    );
-    let cover_path = path.join(export_folder, data.folder, cover[0].name);
 
-    return { cover: fs.readFileSync(cover_path, 'base64')};
-}
-var getRecordingCoverPath = (folder) => {
-    let cover = fs.readdirSync(path.join(export_folder, folder), { withFileTypes: true }).filter(
-        file => (file.isFile() && file.name.split('.').slice(0, 1).join('.') === "cover")
-    );
-    if (_.isEmpty(cover)) {
-        return null;
-    }
-    return encodeURI(path.join(folder, cover[0].name));
-}
 var updateConfig = (data: UpdateDataObject) => {
     console.log(data);
     api_uri = data.config.api_uri;
@@ -645,18 +342,25 @@ var updateConfig = (data: UpdateDataObject) => {
     stream_uri = data.config.stream_uri;
     poll_interval = data.config.poll_interval;
     excluded_djs = data.config.excluded_djs;
-    let new_export_path = path.format(path.parse(data.config.export_folder));
+    let new_export_path;
+    if (data.config.export_folder === "") {
+        new_export_path = path.format(path.parse("."));
+    } else {
+        new_export_path = path.format(path.parse(data.config.export_folder));
+    }
     if (export_folder !== new_export_path && !force_stop) {
         teardown();
         fs.mkdir(new_export_path, (err) => {
             if (err && err.code != 'EEXIST') throw err;
+            export_folder = new_export_path;
+            recording_reader.update_reader(export_folder);
+            app.use(express.static(path.resolve(export_folder)));
         });
-        export_folder = new_export_path;
-        dj_change();
     }
     dj_change();
     return "Changed";
 };
+
 var streamAction = (data) => {
     console.log(data);
     if (data.action === "stop") {
@@ -675,6 +379,7 @@ var printLog = (msg: string) => {
     console.log(msg);
     return msg;
 };
+
 var root = {
     api: getApi,
     server: getServer,
@@ -682,43 +387,36 @@ var root = {
     misc: getMiscData,
     config: getConfigData,
     updateConfig: updateConfig,
-    past_recordings: getPastRecordings,
-    recording_cover: getRecordingCover,
-    full_recording: getRecordedSongs,
+    past_recordings: recording_reader.getPastRecordings,
+    recording_cover: recording_reader.getRecordingCover,
+    full_recording: recording_reader.getRecordedSongs,
     printLog: printLog,
     streamAction: streamAction,
 };
-// GraphQL endpoint
-function start_graqphl() {
-    app = express();
-    app.use(cors()); // For graphql over http
-    app.use('/graphql', express_graphql({
-        schema: schema,
-        rootValue: root,
-        graphiql: true
-    }));
-    app.listen(4000, () => console.log('Express GraphQL Server Now Running On localhost:4000/graphql'));
-}
 
 function stop_everything() {
     app.close()
     http_server.close();
     clearInterval(polling_interval_id);
+};
+
+const options = cli_args(cli.cli_opts);
+
+if (options.process) {
+    recording_processor.process_recording(options.process);
+} else if (options.start) {
+    if (options.load_config) {
+        let load_config = JSON.parse(fs.readFileSync(options.load_config));
+        updateConfig(load_config);
+    };
+    
+    fs.mkdir(export_folder, (err) => {
+        if (err && err.code != 'EEXIST') throw err;
+    });
+    
+    recording_reader.update_reader(export_folder);
+    start_server();
+    start_polling();
+} else {
+    console.log(cli.usage);
 }
-
-const cli_opts = [
-    { name: "load_config", alias: "l", type: String }
-]
-
-const options = cli_args(cli_opts);
-if (options.load_config) {
-    let load_config = JSON.parse(fs.readFileSync(options.load_config));
-    updateConfig(load_config);
-}
-
-fs.mkdir(export_folder, (err) => {
-    if (err && err.code != 'EEXIST') throw err;
-});
-
-start_server();
-start_polling();

--- a/nora.ts
+++ b/nora.ts
@@ -545,7 +545,12 @@ var schema = buildSchema(`
         cover: String
     }
     type full_recording_data {
-        songs: [String]
+        songs: [song_data]
+    }
+    type song_data {
+        title: String
+        artist: String
+        file: String
     }
     input new_config {
         api_uri: String
@@ -604,14 +609,12 @@ var getRecordedSongs = (data) => {
     dirs.sort((a, b) => {
         return a.name.split('.')[0] - b.name.split('.')[0];
     });
-    return { songs: dirs.map(dir => dir.name)};
+    return { songs: dirs.map(dir => getSongMetadata(path.join(export_folder, data.folder), dir.name))};
 };
-var getRecordingSongs = (data) => {
-    let dirs = fs.readdirSync(path.join(export_folder, data.folder), { withFileTypes: true }).filter(
-        file => (file.isFile() && file.name.split(' ').length > 1)
-    );
-    return { songs: dirs.map(dir => dir.name) };
-};
+var getSongMetadata = (folder, file) => {
+    let tags = NodeID3.read(path.join(folder, file));
+    return { title: tags.title, artist: tags.artist, file: file };
+}
 var getSongCount = (folder) => {
     let dirs = fs.readdirSync(path.join(export_folder, folder), { withFileTypes: true }).filter(
         file => (file.isFile() && file.name.split(' ').length > 1)

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@ffprobe-installer/ffprobe": "^1.0.12",
     "@types/node": "^13.1.2",
     "command-line-args": "^5.1.1",
+    "command-line-usage": "^6.1.0",
     "cors": "^2.8.5",
     "express": "^4.17.1",
     "express-graphql": "^0.9.0",


### PR DESCRIPTION
Changed the way the past recordings api operated, setting a static folder based on export_folder, and delivers the song list separate from the list of folders. These changes make Nora incompatible with Nai, and svelte-radio-interface 1.0.0.

Split up the functionality of Nora into several helpers, and included some extra cli functions as well as a -h flag. Also allows for the user to select a previous (not yet processed) recording and parse it.