### PR TITLE
Switched to using cue sheets

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Usage (shorthand) | Description | Example
 --auto_save (-a) | Save changes made in the gui to the config file | `-a`
 --process (-p) | Process a previous recording | `-p my_recording`
 --start (-s) | Start the main program | `-s`
+--cue_split (-k) | Split the cue sheet into compliant cue sheets, rather than create mp3 files | `-p ... -k | -s -k`
 
 When using `--config`, it must be used in conjunction with `--start`, i.e `ts-node nora.ts -c config.json --start`
 

--- a/cli_start.ts
+++ b/cli_start.ts
@@ -2,19 +2,24 @@
 
 import * as cli_args from "command-line-args";
 import { cli_opts, usage } from "./helpers/cli";
-import { load_recording_config } from "./helpers/recording_processor";
+import { createCompliantCueSheets, splitCueSheet } from "./helpers/recording_processor";
 import { print } from "./helpers/shared_functions";
 import { initial_start } from "./index";
 
 const options = cli_args(cli_opts);
 
 if (options.process) {
-  load_recording_config(options.process);
+  if (options.cue_sheets) {
+    createCompliantCueSheets(options.process);
+  } else {
+    splitCueSheet(options.process);
+  }
 } else if (options.start) {
   const start_options = {
     config: options.config,
     default: options.default_config,
     auto: options.auto_save,
+    cueSplit: options.cue_sheets,
   };
   initial_start(start_options);
 } else {

--- a/helpers/cli.ts
+++ b/helpers/cli.ts
@@ -36,8 +36,14 @@ const sections = [
       {
         name: "process",
         alias: "p",
-        typeLabel: "{underline file}",
-        description: "Process a previous recording.",
+        typeLabel: "{underline folder}",
+        description: "Process a previous recording folder into mp3 files.",
+      },
+      {
+        name: "cue_sheets",
+        alias: "k",
+        typeLabel: Boolean,
+        description: "Split a recording into compliant cue sheets instead of mp3 files.",
       },
     ],
   },
@@ -54,5 +60,6 @@ export const cli_opts = [
   { name: "auto_save", alias: "a", type: Boolean },
   { name: "start", alias: "s", type: Boolean },
   { name: "process", alias: "p", type: String },
+  { name: "cue_sheets", alias: "k", type: Boolean },
   { name: "help", alias: "h", type: Boolean },
 ];

--- a/helpers/cue_sheet.ts
+++ b/helpers/cue_sheet.ts
@@ -1,0 +1,54 @@
+import * as fs from "fs";
+import { log_error } from "./shared_functions";
+
+const INDENT = "  ";
+
+export class CueSheet {
+  public current_track: number;
+  public file_path: string;
+
+  constructor(dj: string, timestamp: number | string, path: string) {
+    this.current_track = 1;
+    this.file_path = path;
+    const cue_text = "".concat(`PERFORMER "${dj}"\n`, `TITLE "${timestamp}"\n`, `FILE "raw_recording.mp3" MP3\n`);
+    fs.writeFile(path, cue_text, (err) => {
+      if (err) {
+        log_error(err);
+      }
+    });
+  }
+
+  public add_song(title: string, timestamp: number | string, artist?: string, ending?: string) {
+    return new Promise<void>((resolve) => {
+      let append_text = `${INDENT}TRACK ${this.pad(this.current_track)} AUDIO\n`;
+      append_text = append_text.concat(`${INDENT}${INDENT}TITLE "${title}"\n`);
+      if (artist) {
+        append_text = append_text.concat(`${INDENT}${INDENT}PERFORMER "${artist}"\n`);
+      }
+      append_text = append_text.concat(`${INDENT}${INDENT}INDEX 01 ${this.format_timestamp(timestamp)}\n`);
+      this.current_track += 1;
+      const stream = fs.createWriteStream(this.file_path, { flags: "a" });
+      stream.write(append_text);
+      stream.end();
+      stream.on("finish", () => resolve());
+    });
+  }
+
+  public pad(num: number) {
+    if (num < 10) {
+      return `0${num}`;
+    }
+
+    return num;
+  }
+
+  public format_timestamp(timestamp: number | string) {
+    if (typeof timestamp === "string") {
+      return timestamp;
+    }
+    const minutes = Math.floor(timestamp / 60);
+    const seconds = timestamp % 60;
+
+    return `${this.pad(minutes)}:${this.pad(seconds)}:00`;
+  }
+}

--- a/helpers/recording_reader.ts
+++ b/helpers/recording_reader.ts
@@ -15,10 +15,10 @@ export function update_reader(new_export_folder: string) {
 
 export const getPastRecordings = () => {
   let dirs: string[] = readdirSync(export_folder, { withFileTypes: true })
-    .filter((file: Dirent) => file.isDirectory() && file.name.split(" ").length > 1)
+    .filter((file: Dirent) => file.isDirectory() && file.name.split(" ").length > 1 && getSongCount(file.name) > 0)
     .map((dir: Dirent) => dir.name);
   const result: IPastRecording[] = [];
-  dirs.reverse();
+  dirs = dirs.sort().reverse();
   if (maxDirsSent > 0) {
     dirs = dirs.slice(0, maxDirsSent);
   }
@@ -82,13 +82,32 @@ export const getRecordingCover = (data: { folder: string }) => {
 };
 
 const getRecordingCoverPath = (folder: string) => {
+  const validImageExts = [
+    "png",
+    "jpg",
+    "jpeg",
+    "jfif",
+    "pjpeg",
+    "pjp",
+    "bmp",
+    "gif",
+    "apng",
+    "ico",
+    "cur",
+    "svg",
+    "tif",
+    "tiff",
+    "webp",
+  ];
   const cover = readdirSync(join(export_folder, folder), { withFileTypes: true }).filter(
     (file: Dirent) =>
       file.isFile() &&
-      file.name
-        .split(".")
-        .slice(0, 1)
-        .join(".") === "cover",
+      validImageExts.includes(
+        file.name
+          .split(".")
+          .splice(1, 1)
+          .join("."),
+      ),
   );
   if (isEmpty(cover)) {
     return null;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linkcube-nora",
-  "version": "1.1.7",
+  "version": "1.2.0",
   "description": "Nodejs R/a/dio Archiver",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -36,11 +36,10 @@
     "express-graphql": "^0.9.0",
     "fluent-ffmpeg": "^2.1.2",
     "graphql": "^14.5.8",
-    "lodash": "^4.17.15",
+    "lodash": "^4.17.20",
     "node-id3": "^0.1.11",
     "request": "^2.88.0",
     "request-promise": "^4.2.4",
-    "rimraf": "^3.0.0",
     "sanitize-filename": "^1.6.3",
     "winston": "^3.2.1"
   },
@@ -52,12 +51,11 @@
     "@types/lodash": "^4.14.149",
     "@types/node": "^13.1.2",
     "@types/request-promise": "^4.1.45",
-    "@types/rimraf": "^2.0.3",
     "prettier": "^1.19.1",
     "ts-node": "^8.5.2",
     "tslint": "^5.20.1",
     "tslint-config-prettier": "^1.18.0",
-    "typescript": "^3.7.2"
+    "typescript": "^3.9.7"
   },
   "files": [
     "lib/**/*"


### PR DESCRIPTION
Changed recording metadata to cue sheets that are saved incrementally. The post processing now has the option of splitting into mp3 (as before), or creating cue sheets instead (near instant).
Updated the readme to include the commands for changing to use cue sheets instead of mp3 files.